### PR TITLE
:test_tube: added unit test phase 1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,8 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
+
+      - name: Unit　Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
 name = "anyhow"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -352,48 +358,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling"
-version = "0.20.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.20.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
-dependencies = [
- "darling_core",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
- "serde",
 ]
 
 [[package]]
@@ -425,6 +395,12 @@ checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
 dependencies = [
  "const-random",
 ]
+
+[[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "either"
@@ -493,6 +469,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "futures-channel"
@@ -577,16 +559,16 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "config",
- "keycloak",
+ "mockall",
  "oauth2",
  "prost",
  "serde",
- "serde_json",
  "thiserror 2.0.11",
+ "time",
  "tokio",
+ "tokio-test",
  "tonic",
  "tonic-build",
- "tower 0.5.2",
  "tracing",
  "tracing-subscriber",
 ]
@@ -664,12 +646,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -972,12 +948,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
 name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1006,7 +976,6 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
- "serde",
 ]
 
 [[package]]
@@ -1017,7 +986,6 @@ checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
- "serde",
 ]
 
 [[package]]
@@ -1060,20 +1028,6 @@ dependencies = [
  "pest",
  "pest_derive",
  "serde",
-]
-
-[[package]]
-name = "keycloak"
-version = "26.0.700"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1d908ba7f82228fc5b67d9c8879bb76940d114373164047b470be91a794e463"
-dependencies = [
- "async-trait",
- "percent-encoding",
- "reqwest 0.12.12",
- "serde",
- "serde_json",
- "serde_with",
 ]
 
 [[package]]
@@ -1167,6 +1121,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "multimap"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1208,7 +1188,7 @@ dependencies = [
  "getrandom",
  "http 0.2.12",
  "rand",
- "reqwest 0.11.27",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -1383,6 +1363,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -1590,42 +1596,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqwest"
-version = "0.12.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-core",
- "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.5.2",
- "hyper-util",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 1.0.2",
- "tokio",
- "tower 0.5.2",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "windows-registry",
-]
-
-[[package]]
 name = "ring"
 version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1814,36 +1784,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_with"
-version = "3.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
-dependencies = [
- "base64 0.22.1",
- "chrono",
- "hex",
- "indexmap 1.9.3",
- "indexmap 2.7.0",
- "serde",
- "serde_derive",
- "serde_json",
- "serde_with_macros",
- "time",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "3.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1914,12 +1854,6 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "sval"
@@ -2021,9 +1955,6 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
-dependencies = [
- "futures-core",
-]
 
 [[package]]
 name = "synstructure"
@@ -2070,6 +2001,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
@@ -2128,12 +2065,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde",
  "time-core",
- "time-macros",
 ]
 
 [[package]]
@@ -2141,16 +2076,6 @@ name = "time-core"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
-
-[[package]]
-name = "time-macros"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
-dependencies = [
- "num-conv",
- "time-core",
-]
 
 [[package]]
 name = "tiny-keccak"
@@ -2219,6 +2144,19 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-test"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
+dependencies = [
+ "async-stream",
+ "bytes",
+ "futures-core",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -2342,7 +2280,6 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "sync_wrapper 1.0.2",
- "tokio",
  "tower-layer",
  "tower-service",
 ]
@@ -2666,36 +2603,6 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-registry"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
-dependencies = [
- "windows-result",
- "windows-strings",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
-dependencies = [
- "windows-result",
  "windows-targets 0.52.6",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,20 +9,31 @@ tokio = {version = "1.43.0", features = ["full"]}
 # gRPC
 tonic = "0.12.3"
 prost = "0.13.4"
-tower = "0.5.2"
+
 # 汎用
 thiserror = "2.0.11"
 serde = "1.0.217"
-serde_json = "1.0.135"
 async-trait = "0.1.85"
 # ロギング
 tracing = "0.1.41"
 tracing-subscriber = {version = "0.3.19", features = ["env-filter"]}
 # 認証
 oauth2= {version = "4.4.2", features = ["reqwest", "rustls-tls"]}
-keycloak = "26.0.700"
 # 設定
 config = "0.15.5"
+time = "0.3.37"
 
 [build-dependencies]
 tonic-build = "0.12.3"
+
+[dev-dependencies]
+tokio-test = "0.4.4"
+mockall = "0.13.1"
+
+[lib]
+name = "grpc_auth"
+path = "src/lib.rs"
+
+[[bin]]
+name = "grpc-auth"
+path = "src/main.rs"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# Dockerfile
+FROM rust:1.84 as builder
+
+WORKDIR /usr/src/app
+COPY . .
+
+# 開発依存関係も含めてビルド
+RUN cargo build --all-features
+
+# 実行用のステージ
+FROM rust:1.84-slim
+
+WORKDIR /usr/src/app
+COPY --from=builder /usr/src/app/target ./target
+COPY --from=builder /usr/src/app/config ./config
+
+# デフォルトはサーバー起動、テストの場合はコマンドで上書き
+CMD ["./target/debug/grpc-auth"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+.PHONY: fix
+
+fix:
+	cargo fmt
+	cargo clippy -- -D warnings

--- a/config/test.toml
+++ b/config/test.toml
@@ -1,0 +1,18 @@
+[server]
+host = "0.0.0.0"
+port = 50052
+
+[auth]
+provider_type = "auth0"
+
+[auth.auth0]
+domain = "localhost:8080"
+client_id = "test-client-id"
+client_secret = "test-client-secret"
+audience = "test-audience"
+
+[auth.keycloak]
+realm = "test-realm"
+auth_server_url = "http://localhost:8080/auth"
+client_id = "test-client-id"
+client_secret = "test-client-secret"

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -1,0 +1,18 @@
+version: '3.8'
+
+services:
+  oauth2-mock:
+    image: ghcr.io/navikt/mock-oauth2-server:2.1.0
+    ports:
+      - "8080:8080"
+    environment:
+      SERVER_PORT: 8080
+
+  grpc-auth-test:
+    build: .
+    depends_on:
+      - oauth2-mock
+    command: cargo test --test auth_test -- --nocapture
+    volumes:
+      - .:/usr/src/app
+      - target:/usr/src/app/target

--- a/src/auth/adapters/auth0.rs
+++ b/src/auth/adapters/auth0.rs
@@ -191,6 +191,7 @@ impl Auth0ProviderFactory {
     }
 }
 
+#[async_trait]
 impl AuthProviderFactory for Auth0ProviderFactory {
     type Provider = Auth0Client;
 

--- a/src/auth/domain.rs
+++ b/src/auth/domain.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct TokenResponse {
     pub access_token: String,
     pub token_type: String,
@@ -10,23 +10,23 @@ pub struct TokenResponse {
     pub id_token: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct TokenInfo {
     pub active: bool,
-    pub scope: Option<String>,     // Vec<Scope>からStringに変換
-    pub client_id: Option<String>, // ClientIdからStringに変換
+    pub scope: Option<String>,
+    pub client_id: Option<String>,
     pub sub: Option<String>,
     pub username: Option<String>,
-    pub token_type: Option<String>, // TTからStringに変換
+    pub token_type: Option<String>,
     pub exp: Option<i64>,
     pub iat: Option<i64>,
     pub nbf: Option<i64>,
-    pub aud: Option<String>, // Vec<String>のまま
+    pub aud: Option<String>,
     pub iss: Option<String>,
     pub jti: Option<String>,
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum AuthError {
     #[error("invalid grant")]
     InvalidGrant,

--- a/src/auth/ports.rs
+++ b/src/auth/ports.rs
@@ -20,6 +20,7 @@ pub trait AuthenticationPort: Send + Sync {
     ) -> AuthResult<TokenInfo>;
 }
 
+#[async_trait]
 pub trait AuthProviderFactory {
     type Provider: AuthenticationPort;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,8 +46,12 @@ pub enum ProviderType {
 
 impl Settings {
     pub fn new() -> Result<Self, ConfigError> {
+        Self::new_with_config("config/default")
+    }
+
+    pub fn new_with_config(config_path: &str) -> Result<Self, ConfigError> {
         let config = Config::builder()
-            .add_source(File::with_name("config/default"))
+            .add_source(File::with_name(config_path))
             .add_source(Environment::with_prefix("AUTH_SERVICE"))
             .build()?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod auth;
+pub mod config;
+pub mod generated;

--- a/tests/auth_test.rs
+++ b/tests/auth_test.rs
@@ -1,0 +1,3 @@
+// pub mod integration;
+pub mod common;
+pub mod unit;

--- a/tests/common/mock_auth_server.rs
+++ b/tests/common/mock_auth_server.rs
@@ -1,0 +1,56 @@
+use async_trait::async_trait;
+use grpc_auth::auth::domain::{AuthError, AuthResult, TokenInfo, TokenResponse};
+use grpc_auth::auth::ports::AuthenticationPort;
+use std::sync::Mutex;
+
+pub struct MockAuthServer {
+    pub exchange_token_response: Mutex<Option<TokenResponse>>,
+    pub introspect_token_response: Mutex<Option<TokenInfo>>,
+}
+
+impl MockAuthServer {
+    pub fn new() -> Self {
+        Self {
+            exchange_token_response: Mutex::new(None),
+            introspect_token_response: Mutex::new(None),
+        }
+    }
+
+    pub fn set_exchange_token_response(&self, response: TokenResponse) {
+        *self.exchange_token_response.lock().unwrap() = Some(response);
+    }
+
+    pub fn set_introspect_token_response(&self, response: TokenInfo) {
+        *self.introspect_token_response.lock().unwrap() = Some(response);
+    }
+}
+
+#[async_trait]
+impl AuthenticationPort for MockAuthServer {
+    async fn exchange_token(
+        &self,
+        _grant_type: &str,
+        _code: Option<&str>,
+        _refresh_token: Option<&str>,
+        _redirect_uri: Option<&str>,
+        _code_verifier: Option<&str>,
+    ) -> AuthResult<TokenResponse> {
+        self.exchange_token_response
+            .lock()
+            .unwrap()
+            .clone()
+            .ok_or(AuthError::ProviderError("No mock response set".to_string()))
+    }
+
+    async fn introspect_token(
+        &self,
+        _token: &str,
+        _token_type_hint: Option<&str>,
+    ) -> AuthResult<TokenInfo> {
+        self.introspect_token_response
+            .lock()
+            .unwrap()
+            .clone()
+            .ok_or(AuthError::ProviderError("No mock response set".to_string()))
+    }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,1 @@
+pub mod mock_auth_server;

--- a/tests/integration/grpc_server_test.rs
+++ b/tests/integration/grpc_server_test.rs
@@ -1,0 +1,57 @@
+use std::sync::Arc;
+use tonic::transport::Server;
+use grpc_auth::auth::adapters::auth0::Auth0Client;
+use grpc_auth::auth::adapters::grpc::GrpcAuthService;
+use grpc_auth::config::Settings;
+use grpc_auth::generated::auth::auth_service_server::AuthServiceServer;
+use grpc_auth::generated::auth::auth_service_client::AuthServiceClient;
+use grpc_auth::generated::auth::{GetTokenRequest};
+
+#[tokio::test]
+async fn test_grpc_server_integration() -> Result<(), Box<dyn std::error::Error>> {
+    // テスト用の設定を読み込み（OAuth2モックサーバーの設定を含む）
+    let config = Settings::new_with_config("config/test")
+        .expect("Failed to load test config");
+
+    // 実際のAuth0クライアントを作成
+    let auth_client = Auth0Client::new(config.auth.auth0.clone().unwrap())?;
+    let service = GrpcAuthService::new(Arc::new(auth_client));
+
+    let addr = format!("{}:{}", config.server.host, config.server.port).parse()?;
+    let server = Server::builder()
+        .add_service(AuthServiceServer::new(service))
+        .serve(addr);
+
+    let server_handle = tokio::spawn(server);
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    let channel = tonic::transport::Channel::from_shared(
+        format!("http://{}:{}", config.server.host, config.server.port)
+    )?
+        .connect()
+        .await?;
+
+    let mut client = AuthServiceClient::new(channel);
+
+    let response = client
+        .get_token(GetTokenRequest {
+            grant_type: "authorization_code".to_string(),
+            client_id: config.auth.auth0.as_ref()
+                .map(|c| c.client_id.clone())
+                .unwrap_or_default(),
+            client_secret: config.auth.auth0.as_ref()
+                .map(|c| c.client_secret.clone())
+                .unwrap_or_default(),
+            code: "test_code".to_string(),  // モックサーバーが受け付ける認可コード
+            redirect_uri: "http://localhost/callback".to_string(),
+            code_verifier: "test_verifier".to_string(),
+            refresh_token: String::new(),
+        })
+        .await;
+
+    assert!(response.is_ok());
+
+    server_handle.abort();
+    Ok(())
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -1,0 +1,1 @@
+pub mod grpc_server_test;

--- a/tests/unit/auth0_client_test.rs
+++ b/tests/unit/auth0_client_test.rs
@@ -1,0 +1,171 @@
+use async_trait::async_trait;
+use grpc_auth::auth::domain::{AuthError, AuthResult, TokenInfo, TokenResponse};
+use grpc_auth::auth::ports::{AuthProviderFactory, AuthenticationPort};
+use grpc_auth::config::Auth0Config;
+use std::sync::Mutex;
+
+pub struct MockAuth0Client {
+    exchange_token_response: Mutex<Option<Result<TokenResponse, AuthError>>>,
+    introspect_token_response: Mutex<Option<Result<TokenInfo, AuthError>>>,
+}
+
+impl MockAuth0Client {
+    pub fn new() -> Self {
+        Self {
+            exchange_token_response: Mutex::new(None),
+            introspect_token_response: Mutex::new(None),
+        }
+    }
+
+    pub fn set_exchange_token_response(&self, response: Result<TokenResponse, AuthError>) {
+        *self.exchange_token_response.lock().unwrap() = Some(response);
+    }
+
+    pub fn set_introspect_token_response(&self, response: Result<TokenInfo, AuthError>) {
+        *self.introspect_token_response.lock().unwrap() = Some(response);
+    }
+}
+
+#[async_trait]
+impl AuthenticationPort for MockAuth0Client {
+    async fn exchange_token(
+        &self,
+        _grant_type: &str,
+        _code: Option<&str>,
+        _refresh_token: Option<&str>,
+        _redirect_uri: Option<&str>,
+        _code_verifier: Option<&str>,
+    ) -> AuthResult<TokenResponse> {
+        self.exchange_token_response
+            .lock()
+            .unwrap()
+            .clone()
+            .unwrap_or(Err(AuthError::ProviderError(
+                "No mock response set".to_string(),
+            )))
+    }
+
+    async fn introspect_token(
+        &self,
+        _token: &str,
+        _token_type_hint: Option<&str>,
+    ) -> AuthResult<TokenInfo> {
+        self.introspect_token_response
+            .lock()
+            .unwrap()
+            .clone()
+            .unwrap_or(Err(AuthError::ProviderError(
+                "No mock response set".to_string(),
+            )))
+    }
+}
+
+pub struct Auth0ProviderFactory {
+    config: Auth0Config,
+}
+
+impl Auth0ProviderFactory {
+    pub fn new(config: Auth0Config) -> Self {
+        Self { config }
+    }
+}
+
+#[async_trait]
+impl AuthProviderFactory for Auth0ProviderFactory {
+    type Provider = MockAuth0Client;
+
+    async fn create_provider(&self) -> AuthResult<Self::Provider> {
+        Ok(MockAuth0Client::new())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_exchange_token_authorization_code_success() {
+        let mock_client = MockAuth0Client::new();
+
+        let expected_response = TokenResponse {
+            access_token: "access_token".to_string(),
+            token_type: "Bearer".to_string(),
+            expires_in: 3600,
+            refresh_token: Some("refresh_token".to_string()),
+            id_token: None,
+        };
+
+        mock_client.set_exchange_token_response(Ok(expected_response.clone()));
+
+        let result = mock_client
+            .exchange_token(
+                "authorization_code",
+                Some("auth_code"),
+                None,
+                Some("redirect_uri"),
+                Some("code_verifier"),
+            )
+            .await;
+
+        assert_eq!(result, Ok(expected_response));
+    }
+
+    #[tokio::test]
+    async fn test_exchange_token_refresh_token_success() {
+        let mock_client = MockAuth0Client::new();
+
+        let expected_response = TokenResponse {
+            access_token: "new_access_token".to_string(),
+            token_type: "Bearer".to_string(),
+            expires_in: 3600,
+            refresh_token: Some("new_refresh_token".to_string()),
+            id_token: None,
+        };
+
+        mock_client.set_exchange_token_response(Ok(expected_response.clone()));
+
+        let result = mock_client
+            .exchange_token("refresh_token", None, Some("refresh_token"), None, None)
+            .await;
+
+        assert_eq!(result, Ok(expected_response));
+    }
+
+    #[tokio::test]
+    async fn test_exchange_token_invalid_grant_type() {
+        let mock_client = MockAuth0Client::new();
+        mock_client.set_exchange_token_response(Err(AuthError::InvalidGrant));
+
+        let result = mock_client
+            .exchange_token("invalid_grant", None, None, None, None)
+            .await;
+
+        assert_eq!(result, Err(AuthError::InvalidGrant));
+    }
+
+    #[tokio::test]
+    async fn test_introspect_token_success() {
+        let mock_client = MockAuth0Client::new();
+
+        let expected_info = TokenInfo {
+            active: true,
+            scope: Some("openid profile".to_string()),
+            client_id: Some("client_id".to_string()),
+            username: Some("user".to_string()),
+            exp: Some(1678886400),
+            iat: Some(1678882800),
+            sub: Some("sub".to_string()),
+            aud: Some("aud".to_string()),
+            iss: Some("iss".to_string()),
+            token_type: Some("Bearer".to_string()),
+            nbf: Some(1678882800),
+            jti: Some("jti".to_string()),
+        };
+
+        mock_client.set_introspect_token_response(Ok(expected_info.clone()));
+
+        let result = mock_client.introspect_token("access_token", None).await;
+
+        assert_eq!(result, Ok(expected_info));
+    }
+}

--- a/tests/unit/grpc_test.rs
+++ b/tests/unit/grpc_test.rs
@@ -1,0 +1,36 @@
+use crate::common::mock_auth_server::MockAuthServer;
+use grpc_auth::auth::adapters::grpc::GrpcAuthService;
+use grpc_auth::auth::domain::TokenResponse;
+use grpc_auth::generated::auth::auth_service_server::AuthService;
+use grpc_auth::generated::auth::GetTokenRequest;
+use std::sync::Arc;
+use tonic::Request;
+
+#[tokio::test]
+async fn test_grpc_service_get_token() {
+    let mock_server = Arc::new(MockAuthServer::new());
+
+    // モックレスポンスを設定
+    mock_server.set_exchange_token_response(TokenResponse {
+        access_token: "test_token".to_string(),
+        token_type: "Bearer".to_string(),
+        expires_in: 3600,
+        refresh_token: None,
+        id_token: None,
+    });
+
+    let service = GrpcAuthService::new(mock_server);
+
+    let request = Request::new(GetTokenRequest {
+        grant_type: "authorization_code".to_string(),
+        client_id: "".to_string(),
+        client_secret: "".to_string(),
+        code: "test_code".to_string(),
+        redirect_uri: "http://localhost/callback".to_string(),
+        code_verifier: "test_verifier".to_string(),
+        refresh_token: String::new(),
+    });
+
+    let response = service.get_token(request).await;
+    assert!(response.is_ok());
+}

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -1,0 +1,2 @@
+pub mod auth0_client_test;
+pub mod grpc_test;


### PR DESCRIPTION
## Summary by Sourcery

Auth0クライアントとgRPCサーバーのユニットおよび統合テストを追加。

テスト:
- トークン交換と検証フローの成功と失敗の両方のケースをカバーする、Auth0クライアントのユニットテストを追加。
- モックOAuth2サーバーとの対話を検証する、gRPCサーバーの統合テストを追加。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add unit and integration tests for the Auth0 client and gRPC server.

Tests:
- Added unit tests for the Auth0 client, covering both success and failure cases for token exchange and validation flows.
- Added integration tests for the gRPC server, verifying interaction with a mock OAuth2 server.

</details>

テスト:
- トークン交換と検証フローの成功と失敗の両方のケースをカバーする、Auth0クライアントのユニットテストを追加。
- モックOAuth2サーバーとの対話を検証する、gRPCサーバーの統合テストを追加。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Auth0クライアントとgRPCサーバーのユニットおよび統合テストを追加。

テスト:
- トークン交換と検証フローの成功と失敗の両方のケースをカバーする、Auth0クライアントのユニットテストを追加。
- モックOAuth2サーバーとの対話を検証する、gRPCサーバーの統合テストを追加。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add unit and integration tests for the Auth0 client and gRPC server.

Tests:
- Added unit tests for the Auth0 client, covering both success and failure cases for token exchange and validation flows.
- Added integration tests for the gRPC server, verifying interaction with a mock OAuth2 server.

</details>

</details>

テスト内容:
- Auth0クライアントのユニットテストを追加し、トークン交換と検証フローの成功および失敗のケースをカバー。
- モックOAuth2サーバーとの対話を検証するgRPCサーバーの統合テストを追加。
- テスト目的のモックAuth0クライアントとサーバーを導入。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Auth0クライアントとgRPCサーバーのユニットおよび統合テストを追加。

テスト:
- トークン交換と検証フローの成功と失敗の両方のケースをカバーする、Auth0クライアントのユニットテストを追加。
- モックOAuth2サーバーとの対話を検証する、gRPCサーバーの統合テストを追加。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add unit and integration tests for the Auth0 client and gRPC server.

Tests:
- Added unit tests for the Auth0 client, covering both success and failure cases for token exchange and validation flows.
- Added integration tests for the gRPC server, verifying interaction with a mock OAuth2 server.

</details>

テスト:
- トークン交換と検証フローの成功と失敗の両方のケースをカバーする、Auth0クライアントのユニットテストを追加。
- モックOAuth2サーバーとの対話を検証する、gRPCサーバーの統合テストを追加。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Auth0クライアントとgRPCサーバーのユニットおよび統合テストを追加。

テスト:
- トークン交換と検証フローの成功と失敗の両方のケースをカバーする、Auth0クライアントのユニットテストを追加。
- モックOAuth2サーバーとの対話を検証する、gRPCサーバーの統合テストを追加。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add unit and integration tests for the Auth0 client and gRPC server.

Tests:
- Added unit tests for the Auth0 client, covering both success and failure cases for token exchange and validation flows.
- Added integration tests for the gRPC server, verifying interaction with a mock OAuth2 server.

</details>

</details>

</details>