### PR TITLE
:recycle: update unit test & fixed #5,#6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,6 +561,7 @@ dependencies = [
  "config",
  "mockall",
  "oauth2",
+ "parking_lot",
  "prost",
  "serde",
  "thiserror 2.0.11",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ oauth2= {version = "4.4.2", features = ["reqwest", "rustls-tls"]}
 # 設定
 config = "0.15.5"
 time = "0.3.37"
+parking_lot = "0.12.3"
 
 [build-dependencies]
 tonic-build = "0.12.3"

--- a/tests/unit/auth0_client_test.rs
+++ b/tests/unit/auth0_client_test.rs
@@ -2,27 +2,28 @@ use async_trait::async_trait;
 use grpc_auth::auth::domain::{AuthError, AuthResult, TokenInfo, TokenResponse};
 use grpc_auth::auth::ports::{AuthProviderFactory, AuthenticationPort};
 use grpc_auth::config::Auth0Config;
-use std::sync::Mutex;
+use parking_lot::RwLock;
+use std::sync::Arc;
 
 pub struct MockAuth0Client {
-    exchange_token_response: Mutex<Option<Result<TokenResponse, AuthError>>>,
-    introspect_token_response: Mutex<Option<Result<TokenInfo, AuthError>>>,
+    exchange_token_response: Arc<RwLock<Option<Result<TokenResponse, AuthError>>>>,
+    introspect_token_response: Arc<RwLock<Option<Result<TokenInfo, AuthError>>>>,
 }
 
 impl MockAuth0Client {
     pub fn new() -> Self {
         Self {
-            exchange_token_response: Mutex::new(None),
-            introspect_token_response: Mutex::new(None),
+            exchange_token_response: Arc::new(RwLock::new(None)),
+            introspect_token_response: Arc::new(RwLock::new(None)),
         }
     }
 
     pub fn set_exchange_token_response(&self, response: Result<TokenResponse, AuthError>) {
-        *self.exchange_token_response.lock().unwrap() = Some(response);
+        *self.exchange_token_response.write() = Some(response);
     }
 
     pub fn set_introspect_token_response(&self, response: Result<TokenInfo, AuthError>) {
-        *self.introspect_token_response.lock().unwrap() = Some(response);
+        *self.introspect_token_response.write() = Some(response);
     }
 }
 
@@ -37,8 +38,7 @@ impl AuthenticationPort for MockAuth0Client {
         _code_verifier: Option<&str>,
     ) -> AuthResult<TokenResponse> {
         self.exchange_token_response
-            .lock()
-            .unwrap()
+            .read()
             .clone()
             .unwrap_or(Err(AuthError::ProviderError(
                 "No mock response set".to_string(),
@@ -51,8 +51,7 @@ impl AuthenticationPort for MockAuth0Client {
         _token_type_hint: Option<&str>,
     ) -> AuthResult<TokenInfo> {
         self.introspect_token_response
-            .lock()
-            .unwrap()
+            .read()
             .clone()
             .unwrap_or(Err(AuthError::ProviderError(
                 "No mock response set".to_string(),
@@ -82,6 +81,8 @@ impl AuthProviderFactory for Auth0ProviderFactory {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
+    use tokio::time::sleep;
 
     #[tokio::test]
     async fn test_exchange_token_authorization_code_success() {
@@ -167,5 +168,86 @@ mod tests {
         let result = mock_client.introspect_token("access_token", None).await;
 
         assert_eq!(result, Ok(expected_info));
+    }
+
+    #[tokio::test]
+    async fn test_introspect_token_invalid_token() {
+        let mock_client = MockAuth0Client::new();
+        mock_client.set_introspect_token_response(Err(AuthError::InvalidToken));
+
+        let result = mock_client.introspect_token("invalid_token", None).await;
+        assert_eq!(result, Err(AuthError::InvalidToken));
+    }
+
+    #[tokio::test]
+    async fn test_default_error_when_no_response_set() {
+        let mock_client = MockAuth0Client::new();
+
+        let exchange_result = mock_client
+            .exchange_token("authorization_code", None, None, None, None)
+            .await;
+        assert!(matches!(
+            exchange_result,
+            Err(AuthError::ProviderError(msg)) if msg == "No mock response set"
+        ));
+
+        let introspect_result = mock_client.introspect_token("token", None).await;
+        assert!(matches!(
+            introspect_result,
+            Err(AuthError::ProviderError(msg)) if msg == "No mock response set"
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_factory_creates_new_instance() {
+        let config = Auth0Config {
+            domain: "test.auth0.com".to_string(),
+            client_id: "test_client".to_string(),
+            client_secret: "test_secret".to_string(),
+            audience: "test_audience".to_string(),
+        };
+
+        let factory = Auth0ProviderFactory::new(config);
+        let provider = factory.create_provider().await;
+
+        assert!(provider.is_ok());
+    }
+    #[tokio::test]
+    async fn test_concurrent_access() {
+        let mock_client = Arc::new(MockAuth0Client::new());
+        let mock_client_clone = mock_client.clone();
+
+        let expected_response = Arc::new(TokenResponse {
+            access_token: "test_token".to_string(),
+            token_type: "Bearer".to_string(),
+            expires_in: 3600,
+            refresh_token: None,
+            id_token: None,
+        });
+        let expected_response_clone1 = expected_response.clone();
+        let expected_response_clone2 = expected_response.clone();
+
+        // スレッド1: レスポンスを設定
+        let handle1 = tokio::spawn(async move {
+            mock_client.set_exchange_token_response(Ok((*expected_response_clone1).clone()));
+            sleep(Duration::from_millis(100)).await;
+            mock_client
+                .exchange_token("authorization_code", None, None, None, None)
+                .await
+        });
+
+        // スレッド2: 同じクライアントでレスポンスを取得
+        let handle2 = tokio::spawn(async move {
+            sleep(Duration::from_millis(50)).await;
+            mock_client_clone
+                .exchange_token("authorization_code", None, None, None, None)
+                .await
+        });
+
+        let (result1, result2) = tokio::join!(handle1, handle2);
+        assert!(result1.is_ok());
+        assert!(result2.is_ok());
+        assert_eq!(result1.unwrap(), Ok((*expected_response_clone2).clone()));
+        assert_eq!(result2.unwrap(), Ok((*expected_response).clone()));
     }
 }

--- a/tests/unit/grpc_test.rs
+++ b/tests/unit/grpc_test.rs
@@ -1,36 +1,216 @@
-use crate::common::mock_auth_server::MockAuthServer;
-use grpc_auth::auth::adapters::grpc::GrpcAuthService;
-use grpc_auth::auth::domain::TokenResponse;
-use grpc_auth::generated::auth::auth_service_server::AuthService;
-use grpc_auth::generated::auth::GetTokenRequest;
-use std::sync::Arc;
-use tonic::Request;
+#[cfg(test)]
+mod tests {
+    use grpc_auth::auth::adapters::grpc::GrpcAuthService;
+    use grpc_auth::auth::domain::{AuthError, TokenInfo, TokenResponse};
+    use grpc_auth::auth::ports::AuthenticationPort;
+    use grpc_auth::generated::auth::auth_service_server::AuthService;
+    use grpc_auth::generated::auth::{GetTokenRequest, IntrospectTokenRequest};
+    use std::sync::Arc;
+    use tokio::sync::Mutex;
+    use tonic::{Request, Status};
 
-#[tokio::test]
-async fn test_grpc_service_get_token() {
-    let mock_server = Arc::new(MockAuthServer::new());
+    struct MockAuthService {
+        exchange_token_response: Arc<Mutex<Option<Result<TokenResponse, AuthError>>>>,
+        introspect_token_response: Arc<Mutex<Option<Result<TokenInfo, AuthError>>>>,
+    }
 
-    // モックレスポンスを設定
-    mock_server.set_exchange_token_response(TokenResponse {
-        access_token: "test_token".to_string(),
-        token_type: "Bearer".to_string(),
-        expires_in: 3600,
-        refresh_token: None,
-        id_token: None,
-    });
+    impl MockAuthService {
+        fn new() -> Self {
+            Self {
+                exchange_token_response: Arc::new(Mutex::new(None)),
+                introspect_token_response: Arc::new(Mutex::new(None)),
+            }
+        }
 
-    let service = GrpcAuthService::new(mock_server);
+        async fn set_exchange_token_response(&self, response: Result<TokenResponse, AuthError>) {
+            *self.exchange_token_response.lock().await = Some(response);
+        }
 
-    let request = Request::new(GetTokenRequest {
-        grant_type: "authorization_code".to_string(),
-        client_id: "".to_string(),
-        client_secret: "".to_string(),
-        code: "test_code".to_string(),
-        redirect_uri: "http://localhost/callback".to_string(),
-        code_verifier: "test_verifier".to_string(),
-        refresh_token: String::new(),
-    });
+        async fn set_introspect_token_response(&self, response: Result<TokenInfo, AuthError>) {
+            *self.introspect_token_response.lock().await = Some(response);
+        }
+    }
 
-    let response = service.get_token(request).await;
-    assert!(response.is_ok());
+    #[tonic::async_trait]
+    impl AuthenticationPort for MockAuthService {
+        async fn exchange_token(
+            &self,
+            _grant_type: &str,
+            _code: Option<&str>,
+            _refresh_token: Option<&str>,
+            _redirect_uri: Option<&str>,
+            _code_verifier: Option<&str>,
+        ) -> Result<TokenResponse, AuthError> {
+            self.exchange_token_response
+                .lock()
+                .await
+                .clone()
+                .unwrap_or(Err(AuthError::ProviderError("No response set".to_string())))
+        }
+
+        async fn introspect_token(
+            &self,
+            _token: &str,
+            _token_type_hint: Option<&str>,
+        ) -> Result<TokenInfo, AuthError> {
+            self.introspect_token_response
+                .lock()
+                .await
+                .clone()
+                .unwrap_or(Err(AuthError::ProviderError("No response set".to_string())))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_token_success() {
+        let mock_service = Arc::new(MockAuthService::new());
+        let grpc_service = GrpcAuthService::new(mock_service.clone());
+
+        let expected_response = TokenResponse {
+            access_token: "access_token".to_string(),
+            token_type: "Bearer".to_string(),
+            expires_in: 3600,
+            refresh_token: Some("refresh_token".to_string()),
+            id_token: Some("id_token".to_string()),
+        };
+
+        mock_service
+            .set_exchange_token_response(Ok(expected_response.clone()))
+            .await;
+
+        let request = Request::new(GetTokenRequest {
+            grant_type: "authorization_code".to_string(),
+            client_id: "".to_string(),
+            client_secret: "".to_string(),
+            code: "auth_code".to_string(),
+            refresh_token: "refresh_token".to_string(),
+            redirect_uri: "http://localhost/callback".to_string(),
+            code_verifier: "code_verifier".to_string(),
+        });
+
+        let response = grpc_service.get_token(request).await.unwrap();
+        let response = response.into_inner();
+
+        assert_eq!(response.access_token, expected_response.access_token);
+        assert_eq!(response.token_type, expected_response.token_type);
+        assert_eq!(response.expires_in, expected_response.expires_in);
+        assert_eq!(
+            response.refresh_token,
+            expected_response.refresh_token.unwrap_or_default()
+        );
+        assert_eq!(
+            response.id_token,
+            expected_response.id_token.unwrap_or_default()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_token_error() {
+        let mock_service = Arc::new(MockAuthService::new());
+        let grpc_service = GrpcAuthService::new(mock_service.clone());
+
+        mock_service
+            .set_exchange_token_response(Err(AuthError::InvalidGrant))
+            .await;
+
+        let request = Request::new(GetTokenRequest {
+            grant_type: "invalid_grant".to_string(),
+            client_id: "".to_string(),
+            client_secret: "".to_string(),
+            code: "".to_string(),
+            refresh_token: "".to_string(),
+            redirect_uri: "".to_string(),
+            code_verifier: "".to_string(),
+        });
+
+        let result = grpc_service.get_token(request).await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().code(), tonic::Code::InvalidArgument);
+    }
+
+    #[tokio::test]
+    async fn test_introspect_token_success() {
+        let mock_service = Arc::new(MockAuthService::new());
+        let grpc_service = GrpcAuthService::new(mock_service.clone());
+
+        let expected_info = TokenInfo {
+            active: true,
+            scope: Some("read write".to_string()),
+            client_id: Some("client123".to_string()),
+            username: Some("user@example.com".to_string()),
+            exp: Some(1678886400),
+            iat: Some(1678882800),
+            sub: Some("user123".to_string()),
+            aud: Some("api".to_string()),
+            iss: Some("https://auth.example.com".to_string()),
+            token_type: Some("Bearer".to_string()),
+            nbf: Some(1678882800),
+            jti: Some("token123".to_string()),
+        };
+
+        mock_service
+            .set_introspect_token_response(Ok(expected_info.clone()))
+            .await;
+
+        let request = Request::new(IntrospectTokenRequest {
+            token: "valid_token".to_string(),
+            token_type_hint: "".to_string(),
+        });
+
+        let response = grpc_service.introspect_token(request).await.unwrap();
+        let response = response.into_inner();
+
+        assert_eq!(response.active, expected_info.active);
+        assert_eq!(response.scope, expected_info.scope.unwrap_or_default());
+        assert_eq!(
+            response.client_id,
+            expected_info.client_id.unwrap_or_default()
+        );
+        assert_eq!(
+            response.username,
+            expected_info.username.unwrap_or_default()
+        );
+        assert_eq!(response.exp, expected_info.exp.unwrap_or_default());
+        assert_eq!(response.iat, expected_info.iat.unwrap_or_default());
+    }
+
+    #[tokio::test]
+    async fn test_introspect_token_error() {
+        let mock_service = Arc::new(MockAuthService::new());
+        let grpc_service = GrpcAuthService::new(mock_service.clone());
+
+        mock_service
+            .set_introspect_token_response(Err(AuthError::InvalidToken))
+            .await;
+
+        let request = Request::new(IntrospectTokenRequest {
+            token: "invalid_token".to_string(),
+            token_type_hint: "".to_string(),
+        });
+
+        let result = grpc_service.introspect_token(request).await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().code(), tonic::Code::Unauthenticated);
+    }
+
+    #[test]
+    fn test_auth_error_to_status_conversion() {
+        // 各種エラーの変換をテスト
+        assert_eq!(
+            Status::from(AuthError::InvalidGrant).code(),
+            tonic::Code::InvalidArgument
+        );
+        assert_eq!(
+            Status::from(AuthError::InvalidToken).code(),
+            tonic::Code::Unauthenticated
+        );
+        assert_eq!(
+            Status::from(AuthError::InvalidClient).code(),
+            tonic::Code::Unauthenticated
+        );
+
+        // ProviderErrorの変換をテスト
+        let provider_error = AuthError::ProviderError("test error".to_string());
+        assert_eq!(Status::from(provider_error).code(), tonic::Code::Internal);
+    }
 }


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- GRPCサービスとAuth0クライアントにおけるトークン交換と検証フローの成功および失敗のテストを追加。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tests:
- Add tests for successful and failing token exchange and introspection flows in the GRPC service and Auth0 client.

</details>